### PR TITLE
Fix wrong ns in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ MySQL extensions for [honeysql](https://github.com/seancorfield/honeysql)
 ## Usage
 ### REPL
 ```clj
-(require '[honey.sql.core :as sql]
+(require '[honey.sql :as sql]
          '[honey.sql.helpers :as h]
          '[honey.sql.my.helpers :as mh])
 ```


### PR DESCRIPTION
README에 적힌 ns 중 `honey.sql.core`를 `honey.sql`로 변경합니다!! 😄 