### PR TITLE
insert into - values 구문에서 values에 row alias 붙일 수 있는 함수 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .calva/
 .cpcache/
 .nrepl-port
+.clj-kondo/

--- a/README.md
+++ b/README.md
@@ -77,6 +77,15 @@ Only supports index level hints with select yet
 ;; => ["SELECT /*+ NO_INDEX_MERGE(t1 i_a, i_b) INDEX_MERGE(t1 i_b) */ * FROM t1 WHERE (a = 1) AND (b = 2)"]
 ```
 
+### values with alias
+```clojure
+(-> (h/insert-into :foo)
+    (mh/values-as [{:a 1 :b 2} {:a 3 :b 4}] :new)
+    (h/on-duplicate-key-update {:b :new.b})
+    sql/format)))
+;; => ["INSERT INTO foo (a, b) VALUES (?, ?), (?, ?) AS new ON DUPLICATE KEY UPDATE b = new.b" 1 2 3 4]
+```
+
 ## Run tests
 ```bash
 clj -X:test

--- a/src/honey/sql/my/format.clj
+++ b/src/honey/sql/my/format.clj
@@ -78,13 +78,20 @@
                        sql/format)]
     (update select-sql 0 #(string/replace % #"SELECT" (str "SELECT " hint-sql)))))
 
+(defn values-as-formatter
+  [_op [values alias]]
+  (let [values-sql (sql/format (h/values values))]
+    (update values-sql 0 #(str % " AS " (name alias)))))
+
 (def custom-clauses
   {:insert-ignore-into          {:formatter #'insert-ignore-into-formatter
                                  :before    :columns}
    :explain                     {:formatter #'explain-formatter
                                  :before    :select}
    :select-with-optimizer-hints {:formatter #'select-with-optimizer-hints-formatter
-                                 :before    :from}})
+                                 :before    :from}
+   :values-as                   {:formatter #'values-as-formatter
+                                 :before    :on-duplicate-key-update}})
 
 (def custom-fns
   {:match-against {:formatter #'match-against-formatter}})

--- a/src/honey/sql/my/helpers.clj
+++ b/src/honey/sql/my/helpers.clj
@@ -15,3 +15,7 @@
    TODO) Support other levels optimizer hints"
   [& args]
   (h/generic-helper-variadic :select-with-optimizer-hints args))
+
+(defn values-as
+  [& args]
+  (h/generic-helper-variadic :values-as args))

--- a/test/honey/sql/my/mysql_test.clj
+++ b/test/honey/sql/my/mysql_test.clj
@@ -87,5 +87,13 @@
                (h/where [:and [:= :a 1] [:= :b 2]])
                (sql/format {:inline true}))))))
 
+(deftest values-as-test
+  (testing "use row alias"
+    (is (= ["INSERT INTO foo (a, b) VALUES (?, ?), (?, ?) AS new ON DUPLICATE KEY UPDATE b = new.b" 1 2 3 4]
+           (-> (h/insert-into :foo)
+               (mh/values-as [{:a 1 :b 2} {:a 3 :b 4}] :new)
+               (h/on-duplicate-key-update {:b :new.b})
+               sql/format)))))
+
 (comment
   (run-tests))


### PR DESCRIPTION
<img width="1091" alt="image" src="https://user-images.githubusercontent.com/23634620/199451939-9a64e45a-685c-44e2-a482-32a7eb2421c2.png">

https://dev.mysql.com/doc/refman/8.0/en/insert-on-duplicate.html
MySQL 8.0.19에서는 `values`에 alias를 붙여서 `on duplicate key update` 구문에서 중복되는 row의 경우에는, values의 값을 이용할 수 있도록 하는 문법이 추가되었습니다.

이를 사용할 수 있는 함수를 추가합니다.