### PR TITLE
format이 기존 option overwrite하는 버그 수정

### DIFF
--- a/src/honey/sql/my/format.clj
+++ b/src/honey/sql/my/format.clj
@@ -10,7 +10,7 @@
                       (apply h/insert-into args)
                       (h/insert-into args))
         insert-into' (-> insert-into
-                         sql/format
+                         sql/format-dsl
                          first)
         result (string/replace insert-into' #"INSERT" "INSERT IGNORE")]
     [result]))
@@ -60,7 +60,7 @@
                         (string/join " "))
         hint-sql   (str "/*+ " hints " */")
         select-sql (-> (apply h/select cols)
-                       sql/format)]
+                       sql/format-dsl)]
     (update select-sql 0 #(string/replace % #"SELECT" (str "SELECT " hint-sql)))))
 
 (defn values-as-formatter

--- a/test/honey/sql/my/mysql_test.clj
+++ b/test/honey/sql/my/mysql_test.clj
@@ -85,8 +85,8 @@
                (h/from :t1)
                (h/where [:and [:= :a 1] [:= :b 2]])
                (sql/format {:inline true}))))
-    (is (= ["SELECT /*+ INDEX_MERGE(`t1` `i_a`, `i_b`, `i_c`) */ `col_a`, `col_b`, `col_c` FROM `t1`"]
-           (-> (mh/select-with-optimizer-hints [:col-a :col-b :col-c] [[:index-merge :t1 [:i-a :i-b :i-c]]])
+    (is (= ["SELECT /*+ NO_ORDER_INDEX(`t1` `i_a`, `i_b`, `i_c`) */ `col_a`, `col_b`, `col_c` FROM `t1`"]
+           (-> (mh/select-with-optimizer-hints [:col-a :col-b :col-c] [[:no-order-index :t1 [:i-a :i-b :i-c]]])
                (h/from :t1)
                (sql/format {:dialect :mysql
                             :quoted-snake true})))))


### PR DESCRIPTION
formatter에서 honey.sql/format 함수를 부르면 기존의 opts가 binding에서 overwrite(바깥 scope에서 format을 부를 때 지정한 opts들이 무효화됨)되기 때문에 `honey.sql/format -> honey.sql/format-dsl` 로 교체합니다. [참고](https://github.com/seancorfield/honeysql/blob/develop/src/honey/sql.cljc#L1627)
 
### 기존 결과
<img width="303" alt="image" src="https://user-images.githubusercontent.com/56865498/202629934-b8899419-0aa4-4fed-a41a-148bb226113d.png">
<img width="604" alt="image" src="https://user-images.githubusercontent.com/56865498/202631132-3a2e2bcf-47b0-40a3-a2cc-68825dca6f1a.png">


### 바뀐 결과
<img width="333" alt="image" src="https://user-images.githubusercontent.com/56865498/202630939-57204b0e-449e-4a1a-bbfe-07bcd09895d5.png">
<img width="606" alt="image" src="https://user-images.githubusercontent.com/56865498/202631162-bc48fc12-db10-4523-9142-1720e33576c5.png">



