### PR TITLE
JOIN_PREFIX hint 추가

### DIFF
--- a/src/honey/sql/my/format.clj
+++ b/src/honey/sql/my/format.clj
@@ -45,7 +45,10 @@
     :no-skip-scan})
 
 (def join-level-optimizer-hint-names
-  #{:join-prefix})
+  #{:join-prefix
+    :join-order
+    :join-fixed-order
+    :join-suffix})
 
 (defn hint->hint-format-string
   "Turns a hint into MySQL optimizer hint format string

--- a/src/honey/sql/my/format.clj
+++ b/src/honey/sql/my/format.clj
@@ -74,17 +74,10 @@
       (index-level-optimizer-hint-names hint-name) (hint->hint-format-string hint)
       (join-level-optimizer-hint-names hint-name) (join-level-hint->hint-format-string hint))))
 
-(let [supported-hint-names (set/union index-level-optimizer-hint-names join-level-optimizer-hint-names)]
-  (defn valid-hint-names?
-    "유효한 hint-name을 가지면 true를 리턴합니다."
-    [hint]
-    (supported-hint-names (first hint))))
-
 (defn select-with-optimizer-hints-formatter
   [_op [cols hints]]
   (let [hints      (->> hints
-                        (filter valid-hint-names?)
-                        (map hint->hint-format-string-by-type)
+                        (keep hint->hint-format-string-by-type)
                         (string/join " "))
         hint-sql   (str "/*+ " hints " */")
         select-sql (-> (apply h/select cols)

--- a/src/honey/sql/my/format.clj
+++ b/src/honey/sql/my/format.clj
@@ -2,7 +2,9 @@
   (:require [clojure.string :as string]
             [camel-snake-kebab.core :as csk]
             [honey.sql :as sql]
-            [honey.sql.helpers :as h]))
+            [honey.sql.helpers :as h]
+            [clojure.string :as str]
+            [clojure.set :as set]))
 
 (defn insert-ignore-into-formatter
   [_op args]
@@ -40,8 +42,10 @@
     :order-index
     :no-order-index
     :skip-scan
-    :no-skip-scan
-    :join-prefix})
+    :no-skip-scan})
+
+(def join-level-optimizer-hint-names
+  #{:join-prefix})
 
 (defn hint->hint-format-string
   "Turns a hint into MySQL optimizer hint format string
@@ -53,11 +57,34 @@
           (sql/format-entity table)
           (string/join ", " (map sql/format-entity indexes))))
 
+(defn join-level-hint->hint-format-string
+  "join level 힌트포맷을 리턴합니다"
+  [[hint-name tables]]
+  (let [tables' (->> tables
+                     (map sql/format-entity)
+                     (str/join ", "))
+        hint-name' (csk/->SCREAMING_SNAKE_CASE_STRING hint-name)]
+    (format "%s(%s)" hint-name' tables')))
+
+(defn hint->hint-format-string-by-type
+  "optimizer hint 의 유형에 따른 힌트문자열을 리턴합니다."
+  [hint]
+  (let [hint-name (first hint)]
+    (cond
+      (index-level-optimizer-hint-names hint-name) (hint->hint-format-string hint)
+      (join-level-optimizer-hint-names hint-name) (join-level-hint->hint-format-string hint))))
+
+(let [supported-hint-names (set/union index-level-optimizer-hint-names join-level-optimizer-hint-names)]
+  (defn valid-hint-names?
+    "유효한 hint-name을 가지면 true를 리턴합니다."
+    [hint]
+    (supported-hint-names (first hint))))
+
 (defn select-with-optimizer-hints-formatter
   [_op [cols hints]]
   (let [hints      (->> hints
-                        (filter (fn [[hint-name _ _]] (index-level-optimizer-hint-names hint-name)))
-                        (map hint->hint-format-string)
+                        (filter valid-hint-names?)
+                        (map hint->hint-format-string-by-type)
                         (string/join " "))
         hint-sql   (str "/*+ " hints " */")
         select-sql (-> (apply h/select cols)

--- a/src/honey/sql/my/format.clj
+++ b/src/honey/sql/my/format.clj
@@ -40,7 +40,8 @@
     :order-index
     :no-order-index
     :skip-scan
-    :no-skip-scan})
+    :no-skip-scan
+    :join-prefix})
 
 (defn hint->hint-format-string
   "Turns a hint into MySQL optimizer hint format string

--- a/test/honey/sql/my/mysql_test.clj
+++ b/test/honey/sql/my/mysql_test.clj
@@ -85,7 +85,14 @@
                                                      [:index-merge :t1 [:i-b]]])
                (h/from :t1)
                (h/where [:and [:= :a 1] [:= :b 2]])
-               (sql/format {:inline true}))))))
+               (sql/format {:inline true})))))
+  (testing "INDEX_PREFIX() hint test"
+    (is (= ["SELECT /*+ JOIN_PREFIX(table1 t1, t2) */ * FROM table1 AS t1 LEFT JOIN table2 AS t2 ON t1 = t2 WHERE t1.role = ?" "admin"]
+           (-> (mh/select-with-optimizer-hints [:*] [[:join-prefix :table1 [:t1 :t2]]])
+               (h/from [:table1 :t1])
+               (h/left-join [:table2 :t2] [:= :t1 :t2])
+               (h/where [:= :t1.role "admin"])
+               sql/format)))))
 
 (deftest values-as-test
   (testing "use row alias"

--- a/test/honey/sql/my/mysql_test.clj
+++ b/test/honey/sql/my/mysql_test.clj
@@ -86,9 +86,17 @@
                (h/from :t1)
                (h/where [:and [:= :a 1] [:= :b 2]])
                (sql/format {:inline true})))))
-  (testing "INDEX_PREFIX() hint test"
-    (is (= ["SELECT /*+ JOIN_PREFIX(table1 t1, t2) */ * FROM table1 AS t1 LEFT JOIN table2 AS t2 ON t1 = t2 WHERE t1.role = ?" "admin"]
-           (-> (mh/select-with-optimizer-hints [:*] [[:join-prefix :table1 [:t1 :t2]]])
+  (testing "JOIN_PREFIX() hint test"
+    (is (= ["SELECT /*+ JOIN_PREFIX(t1, t2) */ * FROM table1 AS t1 LEFT JOIN table2 AS t2 ON t1 = t2 WHERE t1.role = ?" "admin"]
+           (-> (mh/select-with-optimizer-hints [:*] [[:join-prefix [:t1 :t2]]])
+               (h/from [:table1 :t1])
+               (h/left-join [:table2 :t2] [:= :t1 :t2])
+               (h/where [:= :t1.role "admin"])
+               sql/format))))
+  (testing "join level hint X index levelt hint"
+    (is (= ["SELECT /*+ JOIN_PREFIX(t1, t2) INDEX_MERGE(t1 i_a, i_b, i_c) */ * FROM table1 AS t1 LEFT JOIN table2 AS t2 ON t1 = t2 WHERE t1.role = ?" "admin"]
+         (-> (mh/select-with-optimizer-hints [:*] [[:join-prefix [:t1 :t2]]
+                                                     [:index-merge :t1 [:i-a :i-b :i-c]]])
                (h/from [:table1 :t1])
                (h/left-join [:table2 :t2] [:= :t1 :t2])
                (h/where [:= :t1.role "admin"])

--- a/test/honey/sql/my/mysql_test.clj
+++ b/test/honey/sql/my/mysql_test.clj
@@ -100,6 +100,14 @@
                (h/from [:table1 :t1])
                (h/left-join [:table2 :t2] [:= :t1 :t2])
                (h/where [:= :t1.role "admin"])
+               sql/format))))
+  (testing "remove unsupported hint test"
+    (is (= (-> (mh/select-with-optimizer-hints [:*] [[:join-prefix [:t1 :t2]]
+                                                     [:index-merge :t1 [:i-a :i-b :i-c]]
+                                                     [:unsupport-merge :a [:i-a :i-b :i-c]]])
+               (h/from [:table1 :t1])
+               (h/left-join [:table2 :t2] [:= :t1 :t2])
+               (h/where [:= :t1.role "admin"])
                sql/format)))))
 
 (deftest values-as-test


### PR DESCRIPTION
JOIN_PREFIX 힌트를 추가하였습니다.


![image](https://user-images.githubusercontent.com/15942102/202651814-4d1b7d59-24b1-44ee-9986-8340b858d93b.png)


--- 

추가개발
1. join-hint 와 index-hint 에 따라 각각 다른 문자열 포맷을 생성하도록변경하였습니다.
2. filter | map 조합을 keep으로 변경해보았습니다.
3. join-hint, index-hint 조합에 따른 테스트를 추가하였습니다.
4. 지원하지 않는 힌트는 무시하는 테스트를 추가하였습니다.
